### PR TITLE
Don't unconditionally call RelationGetIndexList()

### DIFF
--- a/decoder/pg_pb3_ld.c
+++ b/decoder/pg_pb3_ld.c
@@ -313,7 +313,9 @@ pb3ld_change(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
 		if (change->action == REORDER_BUFFER_CHANGE_UPDATE ||
 			change->action == REORDER_BUFFER_CHANGE_DELETE)
 		{
-			RelationGetIndexList(relation);
+			if (!relation->rd_indexvalid)
+				RelationGetIndexList(relation);
+
 			rd_replidindex = relation->rd_replidindex;
 			/* TODO */
 			if (privdata->repl_identity_required && !OidIsValid(rd_replidindex))


### PR DESCRIPTION
This function will even in the short-circuit case do a list_copy().
Instead, make the same check directly on rd_indexvalid that the backend
function does, before calling it conditionally.